### PR TITLE
Fix email verification

### DIFF
--- a/control-panel/routes/web.php
+++ b/control-panel/routes/web.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use ControlPanel\Http\Features\Dashboard\DashboardController;
 use ControlPanel\Http\Middleware\HandleAppearance;
 use ControlPanel\Http\Middleware\HandleInertiaRequests;
+use Illuminate\Auth\Middleware\EnsureEmailIsVerified;
 use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
 use Illuminate\Support\Facades\Route;
 
@@ -16,7 +17,7 @@ Route::prefix('cp')
         AddLinkHeadersForPreloadedAssets::class,
     ])
     ->group(function () {
-        Route::middleware(['auth', 'verified'])->group(function () {
+        Route::middleware(['auth', EnsureEmailIsVerified::redirectTo('cp.verification.notice')])->group(function () {
             Route::redirect('/', '/cp/dashboard');
             Route::get('dashboard', DashboardController::class)->name('cp.dashboard');
         });

--- a/control-panel/src/ControlPanelServiceProvider.php
+++ b/control-panel/src/ControlPanelServiceProvider.php
@@ -6,11 +6,9 @@ namespace ControlPanel;
 
 use App\Assets\Facades\Bundle;
 use App\Models\User;
-use Illuminate\Auth\Middleware\EnsureEmailIsVerified;
 use Illuminate\Auth\Notifications\VerifyEmail;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 
@@ -36,8 +34,6 @@ final class ControlPanelServiceProvider extends ServiceProvider
 
     private function configureEmailVerification(): void
     {
-        Route::aliasMiddleware('verified', EnsureEmailIsVerified::redirectTo('cp.verification.notice'));
-
         VerifyEmail::createUrlUsing(function (User $user) {
             return URL::temporarySignedRoute(
                 'cp.verification.verify',

--- a/control-panel/src/Http/Features/IdentityAccess/Authentication/AuthenticationTest.php
+++ b/control-panel/src/Http/Features/IdentityAccess/Authentication/AuthenticationTest.php
@@ -6,6 +6,7 @@ namespace ControlPanel\Http\Features\IdentityAccess\Authentication;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Route;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 

--- a/control-panel/src/Http/Features/IdentityAccess/Authentication/AuthenticationTest.php
+++ b/control-panel/src/Http/Features/IdentityAccess/Authentication/AuthenticationTest.php
@@ -6,7 +6,6 @@ namespace ControlPanel\Http\Features\IdentityAccess\Authentication;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Route;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 

--- a/control-panel/src/Http/Features/IdentityAccess/EmailVerification/EmailVerificationTest.php
+++ b/control-panel/src/Http/Features/IdentityAccess/EmailVerification/EmailVerificationTest.php
@@ -27,6 +27,16 @@ final class EmailVerificationTest extends TestCase
     }
 
     #[Test]
+    public function users_get_redirected_to_email_verification_screen_when_email_is_not_verified(): void
+    {
+        $user = User::factory()->unverified()->create();
+
+        $response = $this->actingAs($user)->post('/cp');
+
+        $response->assertRedirect(route('cp.verification.notice', absolute: false));
+    }
+
+    #[Test]
     public function email_can_be_verified(): void
     {
         $user = User::factory()->unverified()->create();


### PR DESCRIPTION
Fixes the URL generation to the email verification screen by directly using the middleware in the route file.

Updating a single middleware alias on the HTTP Kernel from a service provider isn't currently possible unfortunately. Updating it on the router is possible, but gets overwritten again unless we wrap it in an `afterResolving` callback.