### PR TITLE
Ignore Vite `hot` files

### DIFF
--- a/storage/hot/.gitignore
+++ b/storage/hot/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Prevent lingering Vite `hot` files. This fixes issues where the app thinks the Vite development server is active thus causing it to serve the incorrect bundle.